### PR TITLE
Add helper to skip tests in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,3 +45,5 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/pest
+        env:
+          RUNNING_IN_CI: true

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -68,6 +68,15 @@ function getFixture(string $name): string
     );
 }
 
+function skipInCI(string $message = 'This test cann\'t run in CI')
+{
+    if(env('RUNNING_IN_CI')) {
+        $this->markTestSkipped($message);
+    }
+
+    return test();
+}
+
 function runDiscoverCommand()
 {
     Artisan::call(


### PR DESCRIPTION
Added a little helper to skip tests in CI

### Usage:
```php
test()->skipInCI();

test()->skipInCI('Some specific message');
```