### PR TITLE
Cleanup uses

### DIFF
--- a/tests/Feature/Actions/CheckModuleIsInstalledTest.php
+++ b/tests/Feature/Actions/CheckModuleIsInstalledTest.php
@@ -2,9 +2,6 @@
 
 use JustSteveKing\Laravel\ERP\Actions\CheckModuleIsInstalled;
 use JustSteveKing\Laravel\ERP\Models\Module;
-use JustSteveKing\Laravel\ERP\Tests\Feature\TestCase;
-
-uses(TestCase::class);
 
 it('returns a module if one is available with the given name')
     ->createModuleWithName('juststeveking/laravel-erp-crm')

--- a/tests/Feature/Actions/ValidateModuleNameTest.php
+++ b/tests/Feature/Actions/ValidateModuleNameTest.php
@@ -1,13 +1,9 @@
 <?php
 
 use Illuminate\Http\Client\RequestException;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Validation\ValidationException;
 use JustSteveKing\Laravel\ERP\Actions\ValidateModuleName;
-use JustSteveKing\Laravel\ERP\Tests\Feature\TestCase;
 use Symfony\Component\HttpFoundation\Response;
-
-uses(TestCase::class);
 
 it('throws an InvalidArgumentException if the module name is found to be invalid locally', function(string $moduleName) {
     ValidateModuleName::handle(module: $moduleName);

--- a/tests/Feature/Commands/DiscoverModulesCommandTest.php
+++ b/tests/Feature/Commands/DiscoverModulesCommandTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use JustSteveKing\Laravel\ERP\Models\Module;
-use JustSteveKing\Laravel\ERP\Tests\Feature\TestCase;
-
-uses(TestCase::class);
 
 it('can discover installed modules using the installed composer packages.')
     ->tap(fn() => runDiscoverCommand())

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -75,9 +75,16 @@ function getFixture(string $name): string
 
 function runDiscoverCommand()
 {
+    $basePath = app()->basePath();
+
+    app()->setBasePath(dirname(__DIR__));
+
     Artisan::call(
         command: DiscoverModulesCommand::class,
     );
+
+    app()->setBasePath($basePath);
+
 
     return test();
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Http;
 use JustSteveKing\Laravel\ERP\Commands\DiscoverModulesCommand;
@@ -19,6 +20,10 @@ use Symfony\Component\HttpFoundation\Response;
 */
 
 uses(TestCase::class)->in('Unit');
+uses(
+    \JustSteveKing\Laravel\ERP\Tests\TestCase::class,
+    RefreshDatabase::class,
+)->in('Feature');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,21 +2,18 @@
 
 declare(strict_types=1);
 
-namespace JustSteveKing\Laravel\ERP\Tests\Feature;
+namespace JustSteveKing\Laravel\ERP\Tests;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use JustSteveKing\Laravel\ERP\ERPServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
-class TestCase extends Orchestra
+abstract class TestCase extends Orchestra
 {
-    use RefreshDatabase;
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loadMigrationsFrom(__DIR__ . '/../../database/migrations');
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }
 
     protected function getPackageProviders($app): array
@@ -38,5 +35,4 @@ class TestCase extends Orchestra
             ]
         );
     }
-
 }


### PR DESCRIPTION
I fixed the `uses` mess where you have defined it in every file.
Moved the `TestCase` to test root and made it abstract.

Fixed failing `DiscoverModulesCommandTest`by setting the `base_path` temporarily to the actual root folder.